### PR TITLE
Fix Unicode character input

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -143,7 +143,8 @@ impl Console {
                             };
 
                             if c != '\0' {
-                                buf.extend_from_slice(&[c as u8]);
+                                let mut b = [0; 4];
+                                buf.extend_from_slice(c.encode_utf8(&mut b).as_bytes());
                             }
                         }
                     }


### PR DESCRIPTION
Characters beyond 0x80 now properly encoded as UTF-8.